### PR TITLE
1.0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@democracy-deutschland/scapacra-bt",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Scapacra Bundestag",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/ConferenceWeekDetail/ConferenceWeekDetailParser.ts
+++ b/src/ConferenceWeekDetail/ConferenceWeekDetailParser.ts
@@ -87,6 +87,8 @@ namespace Parser {
                         const sessionData: string = match;
                         let n;
                         const regex_tops = /<tr>[\s\S]*?<td data-th="Uhrzeit"><p>([\s\S]*?)<\/p><\/td>[\s\S]*?<td data-th="TOP"><p>([\s\S]*?)<\/p><\/td>[\s\S]*?<td data-th="Thema">[\s\S]*?<div class="bt-documents-description">([\s\S]*?)<\/div>[\s\S]*?<\/td>[\s\S]*?<td data-th="Status\/ Abstimmung">([\s\S]*?)<\/td>[\s\S]*?<\/tr>/gm
+                        let lastTopTime: Date | null = null;
+                        let newDay: Boolean = false;
                         while ((n = regex_tops.exec(sessionData)) !== null) {
                             // This is necessary to avoid infinite loops with zero-width matches
                             if (n.index === regex_tops.lastIndex) {
@@ -97,6 +99,15 @@ namespace Parser {
                             n.forEach((match, group) => {
                                 if (group === 1) {
                                     top.time = moment.utc(`${session.dateText} ${match.trim()}`, 'DD MMM YYYY HH:mm', 'de').toDate();
+                                    // Determin if the session is spanning into the new Day
+                                    if (top.time && lastTopTime && lastTopTime.getUTCHours() > top.time.getUTCHours()) {
+                                        newDay = true;
+                                    }
+                                    // If a new Day is detected just increase day by one for each following top
+                                    if(top.time && newDay){
+                                        top.time.setDate(top.time.getDate() + 1);
+                                    }
+                                    lastTopTime = top.time
                                 }
                                 if (group === 2) {
                                     top.top = match.trim();


### PR DESCRIPTION
handle TOP dates correctly for sessions spanning into the next day

already published as v1.0.26